### PR TITLE
Added `jp` lang

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "mangadex-api-types-rust"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/mangadex-api-types/Cargo.toml
+++ b/mangadex-api-types/Cargo.toml
@@ -12,7 +12,7 @@
 [package]
 edition = "2021"
 name = "mangadex-api-types-rust"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["tonymushah <tonymushahdev06@yahoo.com>"]
 description = "Types for mangadex-api"
 license = "MIT OR Apache-2.0"

--- a/mangadex-api-types/src/language.rs
+++ b/mangadex-api-types/src/language.rs
@@ -117,6 +117,7 @@ languages! {
     Italian => "it",
     Japanese => "ja",
     JapaneseRomanized => "ja-ro",
+    Jp => "jp",
     Kazakh => "kk",
     Korean => "ko",
     KoreanRomanized => "ko-ro",
@@ -177,5 +178,17 @@ mod tests {
             let lang = Language::from(test);
             assert_eq!(lang, Language::Unknown);
         }
+    }
+    #[test]
+    fn serde_produces_unknown_from_unknown_string() {
+        #[derive(Deserialize)]
+        struct TestStruct {
+            lang: Language,
+        }
+        let value = serde_json::json!({
+            "lang" : "jp"
+        });
+        let out: TestStruct = serde_json::from_value(value).unwrap();
+        assert_eq!(out.lang, Language::Jp);
     }
 }


### PR DESCRIPTION
When loading special-eureka seasonal title this morning,
I got this error message
```
unknown variant `jp`, expected one of `ar`, `az`, `sq`, `bn`, `bg`, `my`, `ca`, `zh-ro`, `zh`, `zh-hk`, `hr`, `cs`, `da`, `nl`, `en`, `eo`, `et`, `tl`, `fi`, `fr`, `ka`, `de`, `el`, `he`, `hi`, `hu`, `id`, `it`, `ja`, `ja-ro`, `kk`, `ko`, `ko-ro`, `la`, `lt`, `mg`, `ms`, `mn`, `ne`, `kr`, `no`, `fa`, `pl`, `pt-br`, `pt`, `rm`, `ro`, `ru`, `sr`, `sk`, `es`, `es-la`, `sv`, `ta`, `te`, `th`, `tr`, `uk`, `vi`, `NULL`
```
I found the problem,
and this title [Sasaki and Peeps: That Time I Got Dragged into a Psychic Battle in Modern Times While Trying to Enjoy a Relaxing Life in Another World ~Looks Like Magical Girls Are On Deck~](https://mangadex.org/title/54202943-b55d-45a1-830f-44c9a8a691f0) have a `jp` language variant on the `attributes.title`.
The `jp` variant is not registered in the [ISO 639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
Maybe some mistyping from the contributors ?
I don't know...

I just added `jp` language variant just in case.