### PR TITLE
feat: add reference expansion for custom lists

### DIFF
--- a/mangadex-api/src/v5/custom_list/id/get.rs
+++ b/mangadex-api/src/v5/custom_list/id/get.rs
@@ -26,6 +26,7 @@
 //! ```
 
 use derive_builder::Builder;
+use mangadex_api_types::ReferenceExpansionResource;
 use serde::Serialize;
 use uuid::Uuid;
 
@@ -52,6 +53,9 @@ pub struct GetCustomList {
 
     #[serde(skip_serializing)]
     pub list_id: Uuid,
+
+    #[builder(setter(each = "include"), default)]
+    pub includes: Vec<ReferenceExpansionResource>,
 }
 
 endpoint! {


### PR DESCRIPTION
i've seen the custom lists APIs having reference expansions used within the official frontend, and i think it can be useful for grabbing stuff immediately off the lists since the lists themselves only return manga IDs.