### PR TITLE
build: disable default features on `reqwest`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,10 @@ color-print = "0.3.6"
 jsonxf = "1"
 anyhow = "1"
 derive_builder = "0.20"
-reqwest = { version = "0.12", features = [
+reqwest = { version = "0.12", default-features = false, features = [
+    "http2",
+    "charset",
+    "system-proxy",
     "cookies",
     "json",
     "multipart",


### PR DESCRIPTION
this explicitly forces reqwest to correctly use `rustls-tls` instead of
enabling `default-tls` (which defaults to `native-tls`
